### PR TITLE
Update libc6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ADD files/usr/bin/apt-install /usr/bin/apt-install
 # Install wget
 RUN apt-install wget ca-certificates
 
+# Updates
+RUN apt-install libc6
+
 # Install Bats
 RUN wget https://github.com/sstephenson/bats/archive/v0.4.0.tar.gz && \
     tar xzf v0.4.0.tar.gz && cd bats-0.4.0 && ./install.sh /usr/local && \

--- a/test/libc.bats
+++ b/test/libc.bats
@@ -1,0 +1,6 @@
+#!/usr/bin/env bats
+
+@test "It should install a version of glibc protected against CVE-2015-7547" {
+  # Fixed in 2.13.38+deb7u10: https://security-tracker.debian.org/tracker/CVE-2015-7547
+  dpkg -s libc6 | grep -E "^Version: 2\.13-38\+deb7u[1-9][0-9]+$"
+}


### PR DESCRIPTION
The apt-install step can be removed once the official Debian wheezy
Docker image (though it doesn't hurt to have it). The test should stay.

This does rely on the absence of docker caching, but the test will catch
an issue.

---

cc @fancyremarker - do you think Quay will have a cache here or can I merge that as-is?