### PR TITLE
Make apt-install more robust

### DIFF
--- a/files/usr/bin/apt-install
+++ b/files/usr/bin/apt-install
@@ -1,4 +1,7 @@
 #!/bin/sh
+set -o errexit
+set -o nounset
+
 apt-get update
-apt-get -y install $@
+apt-get -y install "$@"
 rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
+ apt-install should fail if apt-get install fails (e.g. because the
  packages cannot be installed, or because --force-yes was needed).
+ apt-install shouldn't re-split the words passed in as input. This is
  probably not **needed** here considering valid package names are also
  valid shell words, but better safe than sorry.


cc @fancyremarker - thoughts? If that works for you I can make PRs against the Ubuntu repo as well.