### PR TITLE
Build in Travis, add Jessie and Stretch

### DIFF
--- a/.docker/config.json.enc
+++ b/.docker/config.json.enc
@@ -1,0 +1,1 @@
+b®çp‘Ø_–'€.‚Jp±PF©‰…"h^tGA‡®`s¥›Ô¹éÎÚCãp5Ä	†žUJº—ªâ”	…\‚ˆ®üS¦ªÅæBŠ­€‡$RãL™™?^A±ôîƒ•µ¢²æ42S0jûöÓÆºhE¿Î’^þÃÏü†É’³2àœü‚~†¡Æè€g¢N˜¦yH\n¨×ƒPÿGæ,e’W¢Öš~cÕÇ5œJùÛK“k™NÂrÑ%˜“UY’/ÓÚb‰í.°¯Âbª"Ï0ßšŸ‡µÌ"'LÛ`#W§[:Í½›ú>Ü+Š@ :çŠH‘k†r“¥©Â…qÛ¨à«Ç`ÕhÈ>Î“óÛYö¥d·&‘:}´2ø¨Ï6:×‰	Ó'ÒfhÑ¯L°'vŒû9ƒm[Üè’î“ccŽ

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.docker/config.json
+*/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: generic
+sudo: true
+
+services:
+  - docker
+
+env:
+  global:
+    - DOCKER_CONFIG=./.docker
+  matrix:
+    - TAG=wheezy
+    - TAG=jessie
+    - TAG=stretch
+
+script:
+  - make build
+  - make test
+
+
+before_deploy:
+  - openssl aes-256-cbc -K "$DOCKER_CONF_key" -iv "$DOCKER_CONF_iv" -in .docker/config.json.enc -out .docker/config.json -d
+
+deploy:
+  provider: script
+  skip_cleanup: true
+  script: make push
+  on:
+    branch: master
+

--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -1,4 +1,4 @@
-FROM debian:wheezy
+FROM debian:<%= ENV.fetch 'TAG' %>
 MAINTAINER Frank Macreery <frank@macreery.com>
 
 # Add custom files

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,121 @@
-DOCKER = docker
-REPO = quay.io/aptible/debian
+# Load the latest tag, and set a default for TAG. The goal here is
+# to ensure TAG is set as early possible, considering it's usually
+# provided as an input anyway, but we want running "make" to
+# *just work*.
 
-TAGS = $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
-ifeq ($(TAGS), wheezy)
-	TAGS = wheezy latest
+include latest.mk
+
+ifndef LATEST_TAG
+$(error LATEST_TAG *must* be set in latest.mk)
 endif
 
-all: release
+ifeq "$(TAG)" "latest"
+override TAG = $(LATEST_TAG)
+endif
 
-release: test build
-	$(DOCKER) push $(REPO)
+TAG ?= $(LATEST_TAG)
 
-build:
-	for tag in $(TAGS) ; do $(DOCKER) build -t $(REPO):$$tag . ; done
+
+# Import configuration. config.mk must set the variables REGISTRY
+# and REPOSITORY so the Makefile knows what to call your image.
+# You can also set PUSH_REGISTRIES and PUSH_TAGS to customize
+# what will be pushed.
+# Finally, you can set any variable that'll be used by your build
+# process, but make sure you export them so they're visible in
+# build programs!
+
+include config.mk
+
+ifndef REGISTRY
+$(error REGISTRY *must* be set in config.mk)
+endif
+
+ifndef REPOSITORY
+$(error REPOSITORY *must* be set in config.mk)
+endif
+
+
+# Create $(TAG)/config.mk if you need to e.g. set environment variables depending
+# on the tag being built. This is typically useful for things constants like a
+# point version, a sha1sum, etc.
+# Note that $(TAG)/config.mk is entirely optional.
+
+-include $(TAG)/config.mk
+
+
+# By default, we'll push the tag we're building, and the 'latest' tag if said
+# tag is indeed the latest one. Set PUSH_TAGS in config.mk (or $(TAG)/config.mk)
+# to override that behavior (note: you can't override the 'latest' tag).
+
+PUSH_TAGS ?= $(TAG)
+
+ifeq "$(TAG)" "$(LATEST_TAG)"
+PUSH_TAGS += latest
+endif
+
+
+# By default, we'll push the registry we're naming the image after. You can
+# override this in config.mk (or $(TAG)/config.mk)
+
+PUSH_REGISTRIES ?= $(REGISTRY)
+
+
+# Export what we're building for e.g. test scripts to use. Exporting
+# other variables is the responsibility of config.mk and $(TAG)/config.mk.
+
+export REGISTRY
+export REPOSITORY
+export TAG
+
+
+# Define actual usable targets
+
+# TODO - Should push depend on test instead? Ideally push is only going to be used by CI anyway.
+push: build
+	set -e ; \
+	for registry in $(PUSH_REGISTRIES); do \
+		for tag in $(PUSH_TAGS); do \
+			docker tag -f "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$${registry}/$(REPOSITORY):$${tag}"; \
+			docker push "$${registry}/$(REPOSITORY):$${tag}"; \
+		done \
+	done
+
+
+test: build
+	set -e ; if [ -f 'test.sh' ]; then ./test.sh; break; fi
+
+
+build: $(TAG)/Dockerfile
+	docker build -t "$(REGISTRY)/$(REPOSITORY):$(TAG)" -f "$(TAG)/Dockerfile" .
+ifeq "$(TAG)" "$(LATEST_TAG)"
+	docker tag -f "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$(REGISTRY)/$(REPOSITORY):latest"
+endif
+
+
+# Per-tag Dockerfile target. Look for Dockerfile or Dockerfile.erb in the root, and use it for $(TAG).
+# We prioritize Dockerfile.erb over Dockerfile if both are present.
+
+$(TAG)/Dockerfile: Dockerfile.erb Dockerfile | $(TAG)
+	set -e ;\
+	if [ -f 'Dockerfile.erb' ]; then \
+		erb "Dockerfile.erb" > "$(TAG)/Dockerfile"; \
+	else \
+		cp "Dockerfile" "$(TAG)/Dockerfile"; \
+	fi
+
+
+# Pseudo targets for Dockerfile and Dockerfile.erb. They don't technically create anything,
+# but each warn if the other file is missing (meaning both files are missing).
+
+Dockerfile.erb:
+	@ if [ ! -f 'Dockerfile' ]; then echo "You must create one of Dockerfile.erb or Dockerfile"; exit 1; fi
+
+Dockerfile:
+	@ if [ ! -f 'Dockerfile.erb' ]; then echo "You must create one of Dockerfile.erb or Dockerfile"; exit 1; fi
+
+$(TAG):
+	mkdir -p "$(TAG)"
+
+
+.PHONY: push test build
+.DEFAULT_GOAL := test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # ![](https://gravatar.com/avatar/11d3bc4c3163e3d238d558d5c9d98efe?s=64) aptible/debian
 
-[![Docker Repository on Quay.io](https://quay.io/repository/aptible/debian/status)](https://quay.io/repository/aptible/debian)
+[![Docker Repository on
+Quay.io](https://quay.io/repository/aptible/debian/status)](https://quay.io/repository/aptible/debian)
+[![Build
+Status](https://travis-ci.org/aptible/docker-debian.svg?branch=master)](https://travis-ci.org/aptible/docker-debian)
 
 Debian base image with custom Aptible patches and Dockerfile building tools.
 
@@ -11,7 +14,9 @@ Debian base image with custom Aptible patches and Dockerfile building tools.
 
 ## Available Tags
 
-* `latest`: Debian 7 (Wheezy)
+* `latest`: Debian 8 (Jessie)
+* `stretch`: Debian 9 (Stretch - not stable yet)
+* `jessie`: Debian 8 (Wheezy)
 * `wheezy`: Debian 7 (Wheezy)
 
 ## Included Tools/Patches

--- a/config.mk
+++ b/config.mk
@@ -1,0 +1,4 @@
+REGISTRY = quay.io
+REPOSITORY = aptible/debian
+
+PUSH_REGISTRIES = $(REGISTRY) docker.io

--- a/latest.mk
+++ b/latest.mk
@@ -1,0 +1,1 @@
+LATEST_TAG = jessie

--- a/test/libc.bats
+++ b/test/libc.bats
@@ -1,6 +1,12 @@
 #!/usr/bin/env bats
 
 @test "It should install a version of glibc protected against CVE-2015-7547" {
-  # Fixed in 2.13.38+deb7u10: https://security-tracker.debian.org/tracker/CVE-2015-7547
-  dpkg -s libc6 | grep -E "^Version: 2\.13-38\+deb7u[1-9][0-9]+$"
+  # https://security-tracker.debian.org/tracker/CVE-2015-7547
+  # Wheezy:  2.13.38+deb7u10
+  # Jessie:  2.19-18+deb8u3
+  # Stretch: 2.21-9
+  dpkg -s libc6 | grep Version
+  dpkg -s libc6 | grep -E "^Version: 2\.13-38\+deb7u[1-9][0-9]+$" || \
+  dpkg -s libc6 | grep -E "^Version: 2\.19-18\+deb8u([3-9]|(\d\d+))$" || \
+  dpkg -s libc6 | grep -E "^Version: 2\.21-9$"
 }


### PR DESCRIPTION
Note: this is targeting the "wheezy" branch, but we should create a master branch before merging this in.

This adds jessie and stretch to our tags. Jessie is the new latest tag. There's little that changed here, and the bigger concern is users that are currently relying on `latest` to be Wheezy. For reference, how did this migration go: https://github.com/aptible/docker-ubuntu/commit/6b3b42482f28e7f5c387b077574d8a018df76efe ?

--

Once this is merged in, we might want to consider updating our DB images that are currently pinned to Wheezy.

cc @fancyremarker 