### PR TITLE
Allow valid libc6 versions >= 2.19-18+deb8u10 on Jessie

### DIFF
--- a/test/libc.bats
+++ b/test/libc.bats
@@ -8,6 +8,6 @@
   dpkg -s libc6 | grep Version
   v="$(dpkg -s libc6 | grep "Version" | sed 's/Version: //g')"
   dpkg -s libc6 | grep -E "^Version: 2\.13-38\+deb7u[1-9][0-9]+$" || \
-  dpkg -s libc6 | grep -E "^Version: 2\.19-18\+deb8u([3-9]|(\d\d+))$" || \
+  dpkg -s libc6 | grep -E "^Version: 2\.19-18\+deb8u([3-9]|([0-9][0-9]+))$" || \
   dpkg --compare-versions "$v" ge "2.21-9"
 }


### PR DESCRIPTION
I think Debian's `grep` doesn't like `\d`, so I replaced that with the explicit character class. Merging in order to pull this in for a rebuild of docker-ruby.

cc: @krallin 