### PR TITLE
Deprecate Wheezy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ services:
 
 env:
   matrix:
-    - TAG=wheezy
     - TAG=jessie
     - TAG=stretch
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Debian base image with custom Aptible patches and Dockerfile building tools.
 ## Available Tags
 
 * `latest`: Debian 8 (Jessie)
-* `stretch`: Debian 9 (Stretch - not stable yet)
+* `stretch`: Debian 9 (Stretch)
 * `jessie`: Debian 8 (Wheezy)
 * `wheezy`: Debian 7 (Wheezy)
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ Debian base image with custom Aptible patches and Dockerfile building tools.
 
 * `latest`: Debian 8 (Jessie)
 * `stretch`: Debian 9 (Stretch)
-* `jessie`: Debian 8 (Wheezy)
-* `wheezy`: Debian 7 (Wheezy)
+* `jessie`: Debian 8 (Jessie)
 
 ## Included Tools/Patches
 


### PR DESCRIPTION
Wheezy is officially EOL, and has finally shut down the package repositories.