### PR TITLE
Update the repo url for Jessie.

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -10,7 +10,7 @@ ADD files/usr/bin/apt-install /usr/bin/apt-install
 # During build, we use a different CDN to allow fixing DSA 4371-1.
 
 RUN SECURITY_LIST=$(mktemp) \
- && echo "deb http://cdn-fastly.deb.debian.org/debian-security <%= ENV.fetch 'TAG' %>/updates main" > "$SECURITY_LIST" \
+ && echo "deb http://security-cdn.debian.org/debian-security <%= ENV.fetch 'TAG' %>/updates main" > "$SECURITY_LIST" \
  && apt-get -o "Dir::Etc::SourceList=${SECURITY_LIST}" -o Acquire::http::AllowRedirect=false update \
  && apt-get -o "Dir::Etc::SourceList=${SECURITY_LIST}" -o Acquire::http::AllowRedirect=false upgrade -y \
  && rm -rf /var/lib/apt/lists/* \


### PR DESCRIPTION
Since debian [moved their repos](https://lists.debian.org/debian-devel-announce/2019/03/msg00006.html), we need to update to update the URL used when avoiding the redirect per DSA 4371-1.

Note, I feel this is largely redundant, as the upstream `FROM debain:$VERSION` images have been patched, but it is also safe to leave these in place unless it causes further issues.