### PR TITLE
Add buster support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,11 @@ services:
 
 env:
   matrix:
-    - TAG=jessie
     - TAG=stretch
+    - TAG=buster
+    # TODO: Add bullseye support, after resolving this error:
+    # E: The repository 'http://security-cdn.debian.org/debian-security bullseye/updates Release' does not have a Release file.
+    # - TAG=bullseye
 
 script:
   - make build


### PR DESCRIPTION
Dropping support for jessie (as it's [past LTS](https://www.debian.org/releases/)).

Not adding bullseye, as there are some errors that will take a bit longer to resolve.