### PR TITLE
fix: added possible switch to how docker debian installs packages for stretch security updates, which have been acrhived

### DIFF
--- a/Dockerfile.erb
+++ b/Dockerfile.erb
@@ -11,11 +11,18 @@ ADD files/usr/bin/apt-install /usr/bin/apt-install
 
 RUN SECURITY_LIST=$(mktemp) \
  && NAME=<%= tag=ENV.fetch('TAG'); %w[stretch buster].include?(tag) ? tag : "#{tag}-security" %> \
- && echo "deb http://security-cdn.debian.org/debian-security ${NAME}/updates main" > "$SECURITY_LIST" \
+ && echo "deb http://<%= tag=ENV.fetch('TAG'); tag == 'stretch' ? "archive.debian.org" : "security-cdn.debian.org" %>/debian-security ${NAME}/updates main" > "$SECURITY_LIST" \
  && apt-get -o "Dir::Etc::SourceList=${SECURITY_LIST}" -o Acquire::http::AllowRedirect=false update \
  && apt-get -o "Dir::Etc::SourceList=${SECURITY_LIST}" -o Acquire::http::AllowRedirect=false upgrade -y \
  && rm -rf /var/lib/apt/lists/* \
  && rm "$SECURITY_LIST"
+
+# This follows: https://stackoverflow.com/a/76094521 as stretch updates have been moved/removed from
+# the original links
+RUN bash -c "if [[ <%= tag=ENV.fetch('TAG') %> == 'stretch' ]]; then \
+    sed -i 's|security.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+    sed -i 's|deb.debian.org|archive.debian.org|g' /etc/apt/sources.list && \
+    sed -i '/stretch-updates/d' /etc/apt/sources.list; fi"
 
 ONBUILD RUN SECURITY_LIST=$(mktemp) \
  && grep security /etc/apt/sources.list > "$SECURITY_LIST" \

--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,11 @@ ifeq "$(TAG)" "$(LATEST_TAG)"
 	docker tag "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$(REGISTRY)/$(REPOSITORY):latest"
 endif
 
+build-local: $(TAG)/Dockerfile
+	docker build --platform=amd64 -t "$(REGISTRY)/$(REPOSITORY):$(TAG)" -f "$(TAG)/Dockerfile" .
+ifeq "$(TAG)" "$(LATEST_TAG)"
+	docker tag "$(REGISTRY)/$(REPOSITORY):$(TAG)" "$(REGISTRY)/$(REPOSITORY):latest"
+endif
 
 # Per-tag Dockerfile target. Look for Dockerfile or Dockerfile.erb in the root, and use it for $(TAG).
 # We prioritize Dockerfile.erb over Dockerfile if both are present.
@@ -117,5 +122,5 @@ $(TAG):
 	mkdir -p "$(TAG)"
 
 
-.PHONY: push test build $(TAG)/Dockerfile
+.PHONY: push test build build-local $(TAG)/Dockerfile
 .DEFAULT_GOAL := test


### PR DESCRIPTION
Related: https://stackoverflow.com/questions/76094428/debian-stretch-repositories-404-not-found

We might just want to switch off stretch itself and not do it this way

bullseye:

<img width="370" alt="image" src="https://user-images.githubusercontent.com/2961973/234915046-1fbfd7df-9f5c-462f-a72f-ca79feea70ae.png">

buster:

<img width="572" alt="image" src="https://user-images.githubusercontent.com/2961973/234915744-2e39590e-bc12-4d01-aef4-27452727d4d9.png">

stretch:

<img width="455" alt="image" src="https://user-images.githubusercontent.com/2961973/234915543-7aec19ee-2001-4c20-8ba9-aac6bacfa8d9.png">
