### PR TITLE
Adding in bookworm as latest version of Debian image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 
 env:
   matrix:
+    - TAG=bookworm
     - TAG=stretch
     - TAG=buster
     - TAG=bullseye

--- a/latest.mk
+++ b/latest.mk
@@ -1,1 +1,1 @@
-LATEST_TAG = bullseye
+LATEST_TAG = bookworm


### PR DESCRIPTION
Adding in `bookworm` as the latest image. This is to build newer repo images off of `bookworm`.